### PR TITLE
Adds support for NOID query API by identifier, DOI, ISBN

### DIFF
--- a/lib/turnsole/heliotrope/service.rb
+++ b/lib/turnsole/heliotrope/service.rb
@@ -93,6 +93,27 @@ module Turnsole
         nil
       end
 
+      def find_noid_by_identifier(identifier:)
+        response = connection.get("noids", identifier: identifier)
+        return response.body if response.success?
+
+        nil
+      end
+
+      def find_noid_by_doi(doi:)
+        response = connection.get("noids", doi: doi)
+        return response.body if response.success?
+
+        nil
+      end
+
+      def find_noid_by_isbn(isbn:)
+        response = connection.get("noids", isbn: isbn)
+        return response.body if response.success?
+
+        nil
+      end
+
       def create_component(identifier:, name:, noid:)
         response = connection.post("components", { component: { identifier: identifier, name: name, noid: noid } }.to_json)
         return response.body["id"] if response.success?

--- a/spec/turnsole/heliotrope/service_spec.rb
+++ b/spec/turnsole/heliotrope/service_spec.rb
@@ -174,4 +174,20 @@ RSpec.describe Turnsole::Heliotrope::Service do
       expect(service.get_product_institution_license(product_identifier: products[i], institution_identifier: institutions[0]['inst_id'])).to be :undefined
     end
   end
+  #These rely on this Monograph on preview: https://heliotrope-preview.hydra.lib.umich.edu/concern/monographs/kw52j9144?locale=en
+  it "finds a NOID by identifier" do
+    expect(service.find_noid_by_identifier(identifier: 'ahab90909')[0]['id']).to eq('kw52j9144')
+  end
+  it "finds a NOID by DOI" do
+    expect(service.find_noid_by_doi(doi: '10.3998/mpub.192640')[0]['id']).to eq('kw52j9144')
+  end
+  it "finds a NOID by DOI URL" do
+    expect(service.find_noid_by_doi(doi: 'https://doi.org/10.3998/mpub.192640')[0]['id']).to eq('kw52j9144')
+  end
+  it "finds a NOID by ISBN (with dashes)" do
+    expect(service.find_noid_by_isbn(isbn: '978-0-472-05122-9')[0]['id']).to eq('kw52j9144')
+  end
+  it "finds a NOID by ISBN (without dashes)" do
+    expect(service.find_noid_by_isbn(isbn: '9780472051229')[0]['id']).to eq('kw52j9144')
+  end
 end


### PR DESCRIPTION
Will close HELIO-3532.